### PR TITLE
Chore/add full name to license component response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [0.0.6] - 2025-08-18
+### Added
+- Added license full name to component license response
+
 ## [0.0.1] - 2022-04-22
 
 [0.0.1]: https://github.com/scanoss/licenses/releases/tag/v0.0.1
+[0.0.6]: https://github.com/scanoss/licenses/releases/tag/v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
-## [0.0.6] - 2025-08-18
+## [0.0.6] - 2025-08-19
 ### Added
 - Added license full name to component license response
 
-## [0.0.1] - 2022-04-22
+## [0.0.5] - 2025-08-14
+### Fixed
+- Fixed naming on licenses installation script
 
-[0.0.1]: https://github.com/scanoss/licenses/releases/tag/v0.0.1
-[0.0.6]: https://github.com/scanoss/licenses/releases/tag/v0.0.2
+## [0.0.4] - 2025-08-14
+### Changed
+- Renamed license-api to licenses-api across the project
+
+## [0.0.3] - 2025-08-13
+### Added
+- Added systemd service unit for SCANOSS License API
+
+## [0.0.2] - 2025-08-13
+### Changed
+- rename package output prefix to `scanoss-license-api`
+
+## [0.0.1] - 2025-08-12
+### Added
+- Added SCANOSS license service
+
+
+[0.0.1]: https://github.com/scanoss/licenses/tag/v0.0.1
+[0.0.2]: https://github.com/scanoss/licenses/compare/v0.0.1...v0.0.2
+[0.0.3]: https://github.com/scanoss/licenses/compare/v0.0.2...v0.0.3
+[0.0.4]: https://github.com/scanoss/licenses/compare/v0.0.3...v0.0.4
+[0.0.5]: https://github.com/scanoss/licenses/compare/v0.0.4...v0.0.5
+[0.0.6]: https://github.com/scanoss/licenses/compare/v0.0.5...v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -68,3 +68,4 @@ require (
 )
 
 //replace github.com/scanoss/papi => ../papi
+// replace github.com/scanoss/go-models => ../go-models

--- a/pkg/middleware/component_middleware.go
+++ b/pkg/middleware/component_middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/scanoss/papi/api/commonv2"
 	"scanoss.com/licenses/pkg/dto"
+	"strings"
 )
 
 type ComponentMiddleware[T any] struct {
@@ -24,6 +25,14 @@ func (m *ComponentMiddleware[TOutput]) Process() (dto.ComponentRequestDTO, error
 	if len(m.req.Purl) == 0 {
 		m.s.Warn("no purl request data supplied to decorate. Ignoring request.")
 		return dto.ComponentRequestDTO{}, errors.New("no purl request data supplied to decorate")
+	}
+
+	purlParts := strings.Split(m.req.Purl, "@")
+
+	if len(purlParts) == 2 {
+		m.s.Debugf("PURL split: %s\n", purlParts)
+		m.req.Purl = purlParts[0]
+		m.req.Requirement = purlParts[1]
 	}
 
 	var componentDTO dto.ComponentRequestDTO


### PR DESCRIPTION
### **WHAT**

### Added
- Added license full name to component license response


NOTE: We must wait for repository authorization on scanoss-model before merging this PR. This PR depends on the latest version of scanoss-model.

Test could failed because of the lack of the scanoss-model access. We need to merge latest changes on the scanoss.model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * License responses now include the license’s full name.
  * Improved PURL handling: supports splitting requirement from PURL using “@”.
* **Bug Fixes**
  * Standardized SPDX detail fields (ID, DetailsURL) and improved not-found handling.
* **Refactor**
  * Streamlined license details: OSADL section and IsFsfLibre field temporarily removed.
* **Documentation**
  * Updated CHANGELOG with full release history and accurate compare/tag links.
* **Chores**
  * Added commented module replacement notes for developers; no dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->