### PR TITLE
feat(license): SP-4243 add nearest version fallback for license lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.1.0] - 2026-04-06
+## [0.1.0] - 2026-04-07
 ### Added
+- Added nearest version fallback for license lookup: when no licenses exist for a specific version, queries all known versions and returns licenses for the nearest version to the requirement
 - Added `go-component-helper` dependency for centralized component version resolution
 - Added per-component `error_message` and `error_code` fields in license responses for failed components
 - Added SPDX license cache with configurable refresh interval (`CACHE_SPDX_REFRESH_HOURS`, default 24h)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module scanoss.com/licenses
 go 1.25.0
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/github/go-spdx/v2 v2.4.0
 	github.com/golobby/config/v3 v3.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -11,7 +12,7 @@ require (
 	github.com/scanoss/go-component-helper v0.6.0
 	github.com/scanoss/go-grpc-helper v0.13.0
 	github.com/scanoss/go-models v0.9.0
-	github.com/scanoss/papi v0.34.0
+	github.com/scanoss/papi v0.34.1
 	github.com/scanoss/zap-logging-helper v0.4.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
@@ -21,7 +22,6 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/scanoss/go-purl-helper v0.3.0 h1:zH5rcYbmYTvKms2oWrYV+8rWZ2ElLgDIOy2j
 github.com/scanoss/go-purl-helper v0.3.0/go.mod h1:3CFUM/OuUp9Q58IF/yGkQhr+G4x6hJNmF8N1f0W82C4=
 github.com/scanoss/ipfilter/v2 v2.0.2 h1:GaB9i8kVJg9JQZm5XGStYkEpiaCVdsrj7ezI2wV/oh8=
 github.com/scanoss/ipfilter/v2 v2.0.2/go.mod h1:AwrpX4XGbZ7EKISMi1d6E5csBk1nWB8+ugpvXHFcTpA=
-github.com/scanoss/papi v0.34.0 h1:hhU0TipfMR9PBKJ34pgW2UNIVRilTxkDTshZfYMJtFg=
-github.com/scanoss/papi v0.34.0/go.mod h1:Z4E/4IpwYdzHHRJXTgBCGG1GjksgrFjNW5cvhbKUfeU=
+github.com/scanoss/papi v0.34.1 h1:QYw0gaLUnlS6IdSjOq2hr1Ld+jfcd8cJ1fi0F2v5lVg=
+github.com/scanoss/papi v0.34.1/go.mod h1:Z4E/4IpwYdzHHRJXTgBCGG1GjksgrFjNW5cvhbKUfeU=
 github.com/scanoss/zap-logging-helper v0.4.0 h1:2qTYoaFa9+MlD2/1wmPtiDHfh+42NIEwgKVU3rPpl0Y=
 github.com/scanoss/zap-logging-helper v0.4.0/go.mod h1:9QuEZcq73g/0Izv1tWeOWukoIK0oTBzM4jSNQ5kRR1w=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pkg/model/purl_licenses.go
+++ b/pkg/model/purl_licenses.go
@@ -100,6 +100,63 @@ func (m *PurlLicensesModel) GetLicensesByPurlVersionAndSource(ctx context.Contex
 	return purlLicenses, nil
 }
 
+// GetLicensesByPurlVersionsAndSource retrieves license data for a purl across multiple versions with source filtering.
+func (m *PurlLicensesModel) GetLicensesByPurlVersionsAndSource(ctx context.Context, purl string, versions []string, sourceID []int16) ([]PurlLicense, error) {
+	s := ctxzap.Extract(ctx).Sugar()
+
+	if len(purl) == 0 {
+		s.Error("Please specify a valid purl to query")
+		return nil, errors.New("please specify a valid purl to query")
+	}
+
+	if len(versions) == 0 {
+		s.Error("Please specify at least one version to query")
+		return nil, errors.New("please specify at least one version to query")
+	}
+
+	if len(sourceID) == 0 {
+		s.Error("Please specify at least one source_id to query")
+		return nil, errors.New("please specify at least one source_id to query")
+	}
+
+	args := []interface{}{purl}
+	paramIdx := 2
+
+	// Build IN clause for versions
+	versionPlaceholders := make([]string, len(versions))
+	for i, v := range versions {
+		versionPlaceholders[i] = fmt.Sprintf("$%d", paramIdx)
+		args = append(args, v)
+		paramIdx++
+	}
+
+	// Build IN clause for source_ids
+	sourcePlaceholders := make([]string, len(sourceID))
+	for i, id := range sourceID {
+		sourcePlaceholders[i] = fmt.Sprintf("$%d", paramIdx)
+		args = append(args, id)
+		paramIdx++
+	}
+
+	query := fmt.Sprintf(
+		"SELECT purl, version, date, source_id, license_id FROM purl_licenses "+
+			"	WHERE purl = $1 AND version IN (%s) AND source_id IN (%s)"+
+			"	AND version != ''",
+		strings.Join(versionPlaceholders, ","),
+		strings.Join(sourcePlaceholders, ","),
+	)
+
+	var purlLicenses []PurlLicense
+	err := m.db.SelectContext(ctx, &purlLicenses, query, args...)
+	if err != nil {
+		s.Errorf("Failed to query purl_licenses table for purl %v, versions count %d, source_ids %v: %v", purl, len(versions), sourceID, err)
+		return nil, fmt.Errorf("failed to query the purl_licenses table: %v", err)
+	}
+
+	s.Debugf("Found %v results for purl %v across %d versions, source_ids %v", len(purlLicenses), purl, len(versions), sourceID)
+	return purlLicenses, nil
+}
+
 // GetLicensesByUnversionedPurlAndSource retrieves license data from unversioned purl with source filtering.
 func (m *PurlLicensesModel) GetLicensesByUnversionedPurlAndSource(ctx context.Context, purl string, sourceID []int16) ([]PurlLicense, error) {
 	s := ctxzap.Extract(ctx).Sugar()

--- a/pkg/usecase/license_usecase.go
+++ b/pkg/usecase/license_usecase.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/jmoiron/sqlx"
 	"github.com/scanoss/go-component-helper/componenthelper"
@@ -86,7 +89,7 @@ func (lu LicenseUseCase) GetComponentsLicense(ctx context.Context, componentDTOs
 				Purl:         c.OriginalPurl,
 				Requirement:  c.OriginalRequirement,
 				Version:      c.Version,
-				ComponentUrl: c.URL,
+				Url:          c.URL,
 				ErrorMessage: &msg,
 				ErrorCode:    domain.StatusCodeToErrorCode(c.Status.StatusCode),
 			})
@@ -100,34 +103,59 @@ func (lu LicenseUseCase) GetComponentsLicense(ctx context.Context, componentDTOs
 func (lu LicenseUseCase) processComponentLicenses(ctx context.Context, s *zap.SugaredLogger,
 	c componenthelper.Component) *pb.ComponentLicenseInfo {
 	componentInfo := &pb.ComponentLicenseInfo{
-		Purl:         c.OriginalPurl,
-		Requirement:  c.OriginalRequirement,
-		ComponentUrl: c.URL,
+		Purl:        c.OriginalPurl,
+		Requirement: c.OriginalRequirement,
+		Url:         c.URL,
 	}
 
 	version := c.Version
-	// Fallback: when GetComponentsVersion did not resolve an exact version (c.Version is empty)
-	// but a requirement was provided (e.g. ">=5.0.0") and known versions exist, attempt to find
-	// the nearest version that satisfies the requirement. This covers cases where no version
-	// exactly matches the requirement range (e.g. requirement ">=5.0.0" with latest version "2.0.0").
-	if c.Version == "" && c.Requirement != "" && len(c.Versions) > 0 {
-		//TODO: Add find nearest version as Component receiver. i.e c.FindNearestVersion()
-		version = comphelputils.FindNearestVersion(c.Requirement, c.Versions)
-		if version == "" {
-			msg := fmt.Sprintf("Version not found for requirement %s", c.Requirement)
-			componentInfo.ErrorCode = domain.StatusCodeToErrorCode(domain.VersionNotFound)
-			componentInfo.ErrorMessage = &msg
-			return componentInfo
-		}
-		msg := fmt.Sprintf("Version not found, using nearest version %s", version)
-		componentInfo.ErrorMessage = &msg
-		// TODO: Add new status RequirementNotMet
-		componentInfo.ErrorCode = domain.StatusCodeToErrorCode(domain.VersionNotFound)
+	var purlLicenses []models.PurlLicense
+
+	// Step 1: Try to fetch licenses for the exact resolved version (e.g. "1.2.3").
+	if version != "" {
+		purlLicenses = lu.fetchLicensesByPurlAndVersion(ctx, s, c.Purl, version)
 	}
+
+	// Step 2: If no licenses were found for the exact version and there are known versions available,
+	// query all known versions at once and pick the nearest version to the requirement that has license data.
+	// If no requirement was provided, fall back to using the resolved version as the reference point.
+	if len(purlLicenses) == 0 && len(c.Versions) > 0 {
+		requirement := c.Requirement
+		if requirement == "" {
+			requirement = c.Version
+		}
+		nearestLicenses, nearestVersion := lu.fetchLicensesByPurlAndVersions(ctx, s, c.Purl, requirement, c.Versions)
+		if len(nearestLicenses) > 0 {
+			purlLicenses = nearestLicenses
+			version = nearestVersion
+			// When a requirement was explicitly provided, check if the nearest version actually satisfies it.
+			// If it doesn't, inform the caller that the returned version doesn't meet the original constraint.
+			if c.Requirement != "" {
+				if !versionSatisfiesRequirement(nearestVersion, c.Requirement) {
+					message := fmt.Sprintf("Version not found for requirement %s, nearest version found: %s", c.Requirement, version)
+					componentInfo.ErrorMessage = &message
+					componentInfo.ErrorCode = domain.StatusCodeToErrorCode(domain.VersionNotFound)
+				}
+			}
+		}
+	}
+
+	// Step 3: Last resort — try fetching licenses from the unversioned purl entry.
+	if len(purlLicenses) == 0 {
+		s.Infof("no purlLicenses data found for purl=%s version=%s. Trying unversioned purl", c.Purl, version)
+		purlLicenses = lu.fetchLicensesByPurl(ctx, s, c.Purl)
+		version = ""
+		componentInfo.ErrorCode = domain.StatusCodeToErrorCode(domain.VersionNotFound)
+		message := "Retrieving licenses for unversioned component"
+		if len(purlLicenses) > 0 && c.Requirement != "" {
+			message = fmt.Sprintf("Licenses for requirement %s not found, retrieving licenses for unversioned component", c.Requirement)
+		}
+		componentInfo.ErrorMessage = &message
+	}
+
 	componentInfo.Version = version
 
-	purlLicenses := lu.fetchPurlLicenses(ctx, s, c, version)
-	if purlLicenses == nil {
+	if len(purlLicenses) == 0 {
 		message := fmt.Sprintf("License info not found for %s", c.Purl)
 		componentInfo.ErrorMessage = &message
 		componentInfo.ErrorCode = domain.StatusCodeToErrorCode(domain.ComponentWithoutInfo)
@@ -170,37 +198,76 @@ func (lu LicenseUseCase) processComponentLicenses(ctx context.Context, s *zap.Su
 	return componentInfo
 }
 
-func (lu LicenseUseCase) fetchPurlLicenses(ctx context.Context, s *zap.SugaredLogger,
-	c componenthelper.Component, version string) []models.PurlLicense {
-	sources := []int16{
+func (lu LicenseUseCase) getLicenseSources() []int16 {
+	return []int16{
 		license.SourceComponentDeclared,
 		license.SourceAttributionFile,
-		license.SourceSPDXAttributionFiles,
 		license.SourceInternalAttributionFiles,
+		license.SourceSPDXAttributionFiles,
 	}
+}
 
-	purlLicenses, err := lu.purlLicenseModel.GetLicensesByPurlVersionAndSource(ctx, c.Purl, version, sources)
+// fetchLicensesByPurlAndVersion retrieves licenses for a specific purl and version.
+func (lu LicenseUseCase) fetchLicensesByPurlAndVersion(ctx context.Context, s *zap.SugaredLogger,
+	purl, version string) []models.PurlLicense {
+	purlLicenses, err := lu.purlLicenseModel.GetLicensesByPurlVersionAndSource(ctx, purl, version, lu.getLicenseSources())
 	if err != nil {
-		s.Warnf("error when querying GetVersionedAndUnversionedLicenses() for purl=%s version=%s: %v", c.Purl, version, err)
+		s.Warnf("error when querying GetLicensesByPurlVersionAndSource() for purl=%s version=%s: %v", purl, version, err)
 		return nil
 	}
+	return purlLicenses
+}
 
-	if len(purlLicenses) == 0 {
-		s.Info("no purlLicenses data found for purl=%s version=%s. Trying with unversioned purl", c.Purl, version)
-		purlLicenses, err = lu.purlLicenseModel.GetLicensesByUnversionedPurlAndSource(ctx, c.Purl, sources)
-
-		if err != nil {
-			s.Warnf("error when querying GetLicensesByUnversionedPurlAndSource() for purl=%s: %v", c.Purl, err)
-			return nil
-		}
-
-		if len(purlLicenses) == 0 {
-			s.Info("no purlLicenses data found for unversioned purl=%s.", c.Purl, version)
-			return nil
-		}
+// fetchLicensesByPurlAndVersions retrieves licenses across multiple versions for a purl
+// and returns the licenses for the nearest version to the requirement.
+func (lu LicenseUseCase) fetchLicensesByPurlAndVersions(ctx context.Context, s *zap.SugaredLogger,
+	purl, requirement string, versions []string) ([]models.PurlLicense, string) {
+	allVersionLicenses, err := lu.purlLicenseModel.GetLicensesByPurlVersionsAndSource(ctx, purl, versions, lu.getLicenseSources())
+	if err != nil {
+		s.Warnf("error when querying GetLicensesByPurlVersionsAndSource() for purl=%s: %v", purl, err)
+		return nil, ""
+	}
+	if len(allVersionLicenses) == 0 {
+		return nil, ""
 	}
 
+	// Group licenses by version
+	licensesByVersion := make(map[string][]models.PurlLicense)
+	for _, pl := range allVersionLicenses {
+		licensesByVersion[pl.Version] = append(licensesByVersion[pl.Version], pl)
+	}
+
+	nearestVersion := comphelputils.FindNearestVersion(requirement, slices.Collect(maps.Keys(licensesByVersion)))
+	if nearestVersion == "" {
+		return nil, ""
+	}
+
+	s.Debugf("using nearest version %s (from %d available) for purl=%s", nearestVersion, len(licensesByVersion), purl)
+	return licensesByVersion[nearestVersion], nearestVersion
+}
+
+// fetchLicensesByPurl retrieves licenses for an unversioned purl.
+func (lu LicenseUseCase) fetchLicensesByPurl(ctx context.Context, s *zap.SugaredLogger,
+	purl string) []models.PurlLicense {
+	purlLicenses, err := lu.purlLicenseModel.GetLicensesByUnversionedPurlAndSource(ctx, purl, lu.getLicenseSources())
+	if err != nil {
+		s.Warnf("error when querying GetLicensesByUnversionedPurlAndSource() for purl=%s: %v", purl, err)
+		return nil
+	}
 	return purlLicenses
+}
+
+// versionSatisfiesRequirement checks if a version satisfies a semver constraint/requirement.
+func versionSatisfiesRequirement(version, requirement string) bool {
+	c, err := semver.NewConstraint(requirement)
+	if err != nil {
+		return false
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return c.Check(v)
 }
 
 func (lu LicenseUseCase) resolveSPDXLicenses(ctx context.Context, s *zap.SugaredLogger,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License lookup now falls back: exact version → nearest matching known version → unversioned, improving discovery when exact matches are missing.

* **Behavior Changes**
  * Nearest-version candidates are validated against provided version requirements; failures produce explicit version-not-found reporting.
  * Component URL field populated consistently in license responses.

* **Refactor**
  * License resolution flow reorganized for more robust multi-version handling.

* **Chores**
  * Dependency updates.

* **Documentation**
  * Release notes and changelog date updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->