### PR TITLE
fix(license): SP-4288 return failed components in GetComponentsLicense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2026-04-14
+### Fixed
+- Fixed `GetComponentsLicense` dropping components with resolution errors from the response; failed components are now included alongside successful lookup results.
+
 ## [0.2.0] - 2026-04-10
 ### Added
 - Added `LOOKUP_SOURCE_PRIORITY` configuration (env var and JSON `Lookup.SourcePriority`) to control the ordered priority of license detection sources. Sources are walked from highest to lowest priority, stopping at the first source that returns license data. See [README](README.md#license-lookup-source-priority) for details.
@@ -58,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed default ports: REST `40057`, gRPC `50057`, and logging `66057`
 
 
+[0.2.1]: https://github.com/scanoss/licenses/releases/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/scanoss/licenses/releases/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scanoss/licenses/releases/compare/v0.0.7...v0.1.0
 [0.0.7]: https://github.com/scanoss/licenses/releases/compare/v0.0.6...v0.0.7

--- a/pkg/handler/license_handler_test.go
+++ b/pkg/handler/license_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/jmoiron/sqlx"
 	"github.com/scanoss/go-component-helper/componenthelper"
+	"github.com/scanoss/go-grpc-helper/pkg/grpc/domain"
 	zlog "github.com/scanoss/zap-logging-helper/pkg/logger"
 	"net/http"
 	"os"
@@ -133,6 +134,36 @@ func TestLicenseHandler_GetLicenses(t *testing.T) {
 			t.Errorf("Expected SUCCESS status, got %v", response.Status.Status)
 		}
 
+	})
+
+	t.Run("includes failed components alongside successful ones", func(t *testing.T) {
+		mockMW := &mockMiddleware{
+			processFunc: func() ([]componenthelper.ComponentDTO, error) {
+				return []componenthelper.ComponentDTO{
+					{Purl: "pkg:gitlab/gpl/project", Requirement: "1.0.0"},
+					{Purl: "pkg:npm/this-does-not-exist", Requirement: "9.9.9"},
+				}, nil
+			},
+		}
+
+		response, err := handler.GetComponentsLicense(ctx, mockMW)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if response == nil {
+			t.Fatal("Expected response, got nil")
+		}
+		if got := len(response.Components); got != 2 {
+			t.Fatalf("Expected 2 components in response, got %d", got)
+		}
+
+		for _, c := range response.Components {
+			if c.Purl == "pkg:npm/this-does-not-exist" {
+				if *c.ErrorCode.Enum() != *domain.StatusCodeToErrorCode(domain.ComponentNotFound) {
+					t.Errorf("Expected error code %v for component %s, got %v", domain.ComponentNotFound, c.Purl, c.ErrorCode.Enum())
+				}
+			}
+		}
 	})
 }
 

--- a/pkg/usecase/license_usecase.go
+++ b/pkg/usecase/license_usecase.go
@@ -124,12 +124,12 @@ func (lu LicenseUseCase) GetComponentsLicense(ctx context.Context, componentDTOs
 		S:          s,
 		Input:      componentDTOs,
 	})
-	clir := make([]*pb.ComponentLicenseInfo, 0, len(processedComponents))
+	failedResults := make([]*pb.ComponentLicenseInfo, 0, len(processedComponents))
 	var toProcess []componenthelper.Component
 	for _, c := range processedComponents {
 		if c.Status.StatusCode != domain.Success && c.Status.StatusCode != domain.VersionNotFound {
 			msg := c.Status.Message
-			clir = append(clir, &pb.ComponentLicenseInfo{
+			failedResults = append(failedResults, &pb.ComponentLicenseInfo{
 				Purl:         c.OriginalPurl,
 				Requirement:  c.OriginalRequirement,
 				Version:      c.Version,
@@ -141,10 +141,11 @@ func (lu LicenseUseCase) GetComponentsLicense(ctx context.Context, componentDTOs
 		}
 		toProcess = append(toProcess, c)
 	}
-	if len(toProcess) == 0 {
-		return clir, nil
+	results := make([]*pb.ComponentLicenseInfo, 0, len(componentDTOs))
+	results = append(results, failedResults...)
+	if len(toProcess) > 0 {
+		results = append(results, lu.componentsLicenseWorker(ctx, s, toProcess)...)
 	}
-	results := lu.componentsLicenseWorker(ctx, s, toProcess)
 	return results, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Components that fail license lookup are now included in responses with appropriate error codes, instead of being dropped from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->